### PR TITLE
F continuous play

### DIFF
--- a/ui_map_config.py
+++ b/ui_map_config.py
@@ -24,7 +24,7 @@ class UIMapConfig(tk.Toplevel):
         self.items = {}
         self.sides = {}
 
-        self.container = uiQuietFrame(self)
+        self.container = uiQuietFrame(master=self)
         self.container.pack(fill=tk.BOTH, expand=True, side=tk.TOP)
         self.grid_rowconfigure(0, weight=1)
         self.grid_columnconfigure(0, weight=1)

--- a/ui_sim.py
+++ b/ui_sim.py
@@ -117,7 +117,7 @@ class UISim(tk.Toplevel):
         self.btn_run = uiButton(
             master = self.btn_frame_1,
             text = "Run",
-            command=self.run_continuous
+            command=self.run_continuous_proxy
         )
         self.btn_run.pack(
             fill=tk.BOTH, 
@@ -350,7 +350,8 @@ class UISim(tk.Toplevel):
             self.update_objects()
             self.update_items()
 
-    def run_continuous(self):
+    def run_continuous_proxy(self):
+        """A proxy function for continuous mode"""
         self.continuous_run = True
         
         delay = self.delay_entry.get()
@@ -359,9 +360,14 @@ class UISim(tk.Toplevel):
         else:
             delay = DEFAULT_TURN_DELAY_IN_MS
         
-        self.run_continuous_proxy(delay)
+        self.run_continuous(delay)
 
-    def run_continuous_proxy(self, delay):
+    def run_continuous(self, delay):
+        """Responsible for continuous mode
+        
+        This function is rescheduled using tk's after method
+        to create a continuous mode.
+        """
 
         # Will abort running another turn if the user has clicked
         #   pause between turns.
@@ -376,9 +382,10 @@ class UISim(tk.Toplevel):
             self.display_scoreboard()
         else:
             if self.continuous_run:
-                self.btn_run.after(delay, self.run_continuous_proxy, delay)
+                self.btn_run.after(delay, self.run_continuous, delay)
 
     def pause_continuous(self):
+        """Pauses continuous mode"""
         self.continuous_run = False
 
     def display_points(self):

--- a/ui_sim.py
+++ b/ui_sim.py
@@ -363,6 +363,11 @@ class UISim(tk.Toplevel):
 
     def run_continuous_proxy(self, delay):
 
+        # Will abort running another turn if the user has clicked
+        #   pause between turns.
+        if not self.continuous_run:
+            return
+
         game_ended = self.sim.run_sim(1)
         self.update_objects()
         self.update_items()
@@ -371,7 +376,7 @@ class UISim(tk.Toplevel):
             self.display_scoreboard()
         else:
             if self.continuous_run:
-                self.btn_run.after(500, self.run_continuous_proxy, delay)
+                self.btn_run.after(delay, self.run_continuous_proxy, delay)
 
     def pause_continuous(self):
         self.continuous_run = False

--- a/ui_sim.py
+++ b/ui_sim.py
@@ -107,79 +107,47 @@ class UISim(tk.Toplevel):
         self.main_log_scroll.configure(state="disabled")
 
         # Add the buttons
-        
+
         # self.data_frame_2 = uiQuietFrame(master=self.log_frame)
         # self.data_frame_2.pack(fill=tk.BOTH,expand=True,side=tk.TOP)
 
         self.btn_frame_1 = uiQuietFrame(master=self.log_frame)
         self.btn_frame_1.pack(fill=tk.BOTH, expand=True, side=tk.TOP)
-        
+
         self.btn_run = uiButton(
-            master = self.btn_frame_1,
-            text = "Run",
-            command=self.run_continuous_proxy
+            master=self.btn_frame_1, text="Run", command=self.run_continuous_proxy
         )
-        self.btn_run.pack(
-            fill=tk.BOTH, 
-            expand=True, 
-            side=tk.LEFT
-        )
+        self.btn_run.pack(fill=tk.BOTH, expand=True, side=tk.LEFT)
         self.btn_pause = uiButton(
-            master = self.btn_frame_1,
-            text = "Pause",
-            command=self.pause_continuous
+            master=self.btn_frame_1, text="Pause", command=self.pause_continuous
         )
-        self.btn_pause.pack(
-            fill=tk.BOTH, 
-            expand=True, 
-            side=tk.LEFT
-        )
+        self.btn_pause.pack(fill=tk.BOTH, expand=True, side=tk.LEFT)
         self.delay_label = uiLabel(master=self.btn_frame_1, text="Delay (ms)")
         self.delay_label.pack(fill=tk.BOTH, expand=True, side=tk.LEFT)
         self.delay_entry = uiEntry(master=self.btn_frame_1)
         self.delay_entry.pack(fill=tk.BOTH, expand=True, side=tk.LEFT)
-        
 
         self.btn_frame_2 = uiQuietFrame(master=self.log_frame)
         self.btn_frame_2.pack(fill=tk.BOTH, expand=True, side=tk.TOP)
         self.turns_button = uiButton(
-            master=self.btn_frame_2, 
-            text="Run X Turns", 
-            command=self.run_x_turns
+            master=self.btn_frame_2, text="Run X Turns", command=self.run_x_turns
         )
-        self.turns_button.pack(
-            fill=tk.BOTH, 
-            expand=True, 
-            side=tk.LEFT
-        )
+        self.turns_button.pack(fill=tk.BOTH, expand=True, side=tk.LEFT)
         self.turns_label = uiLabel(master=self.btn_frame_2, text="Turns To Run")
         self.turns_label.pack(fill=tk.BOTH, expand=True, side=tk.LEFT)
         self.turns_entry = uiEntry(master=self.btn_frame_2)
         self.turns_entry.pack(fill=tk.BOTH, expand=True, side=tk.LEFT)
 
-
         self.btn_frame_3 = uiQuietFrame(master=self.log_frame)
         self.btn_frame_3.pack(fill=tk.BOTH, expand=True, side=tk.TOP)
         self.display_points_button = uiButton(
-            master=self.btn_frame_3, 
-            text="Display Points", 
-            command=self.display_points
+            master=self.btn_frame_3, text="Display Points", command=self.display_points
         )
-        self.display_points_button.pack(
-            fill=tk.BOTH, 
-            expand=True, 
-            side=tk.LEFT
-        )
+        self.display_points_button.pack(fill=tk.BOTH, expand=True, side=tk.LEFT)
         self.end_game_button = uiButton(
-            master=self.btn_frame_3,
-            text="End Game",
-            command=self.display_scoreboard
+            master=self.btn_frame_3, text="End Game", command=self.display_scoreboard
         )
-        self.end_game_button.pack(
-            fill=tk.BOTH, 
-            expand=True, 
-            side=tk.LEFT
-        )
+        self.end_game_button.pack(fill=tk.BOTH, expand=True, side=tk.LEFT)
 
         self.log_frame.after(100, self.update_log)
 
@@ -338,9 +306,9 @@ class UISim(tk.Toplevel):
 
             turns_to_run = int(turns_to_run)
             game_ended = False
-            
+
             while turns_to_run > 0:
-               
+
                 game_ended = self.sim.run_sim(1)
                 turns_to_run -= 1
                 if game_ended:
@@ -353,18 +321,18 @@ class UISim(tk.Toplevel):
     def run_continuous_proxy(self):
         """A proxy function for continuous mode"""
         self.continuous_run = True
-        
+
         delay = self.delay_entry.get()
         if delay.isdigit():
             delay = int(delay)
         else:
             delay = DEFAULT_TURN_DELAY_IN_MS
-        
+
         self.run_continuous(delay)
 
     def run_continuous(self, delay):
         """Responsible for continuous mode
-        
+
         This function is rescheduled using tk's after method
         to create a continuous mode.
         """


### PR DESCRIPTION
Adds a continuous mode with some suggested UI changes to accommodate. A new entry field was added to allow the user to enter a custom delay. If the field is empty or contains garbage a default of 500 ms is used. 

Restructures the turn-by-turn mode function so that run_sim is called for every turn, rather than all at once. This isn't a necessary change, but it brings it's function in line with the new continuous mode. This obviates the need for run_sim to have a "number of turns to run" parameter. Currently leaving it because it might be useful later or we might want to fall back.

Also, I fixed an error in the show map of advanced config. Line 27 was giving an error on the number of arguments. Explicitly assigning self to master fixed the issue.